### PR TITLE
IOS-1035 - Match Apple's Photos app duration format and rounding off.

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -475,10 +475,8 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     // Video indicator
     if (asset.mediaType == PHAssetMediaTypeVideo) {
         cell.videoIndicatorView.hidden = NO;
-        
-        NSInteger minutes = (NSInteger)(asset.duration / 60.0);
-        NSInteger seconds = (NSInteger)ceil(asset.duration - 60.0 * (double)minutes);
-        cell.videoIndicatorView.timeLabel.text = [NSString stringWithFormat:@"%02ld:%02ld", (long)minutes, (long)seconds];
+
+        cell.videoIndicatorView.timeLabel.text = [self formattedDurationFromTimeInterval:asset.duration];
         
         if (asset.mediaSubtypes & PHAssetMediaSubtypeVideoHighFrameRate) {
             cell.videoIndicatorView.videoIcon.hidden = YES;
@@ -499,6 +497,35 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     }
     
     return cell;
+}
+
+- (NSDateComponentsFormatter *)durationFormatterForTimeInterval:(NSTimeInterval)interval {
+    NSDateComponentsFormatter *formatter = [[NSDateComponentsFormatter alloc] init];
+    formatter.unitsStyle = NSDateComponentsFormatterUnitsStylePositional;
+
+    if (interval >= 3600) { // 1 hour = 3600 seconds
+        formatter.allowedUnits = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+    } else {
+        formatter.allowedUnits = NSCalendarUnitMinute | NSCalendarUnitSecond;
+    }
+
+    formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
+    return formatter;
+}
+
+- (NSString *)formattedDurationFromTimeInterval:(NSTimeInterval)interval {
+    // Round the interval to the nearest second
+    interval = round(interval);
+    
+    NSDateComponentsFormatter *formatter = [self durationFormatterForTimeInterval:interval];
+    NSString *formattedString = [formatter stringFromTimeInterval:interval];
+
+    // Remove leading zero for minutes
+    if ([formattedString hasPrefix:@"0"]) {
+        formattedString = [formattedString substringFromIndex:1];
+    }
+
+    return formattedString;
 }
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/QBImagePickerDemo/Info.plist
+++ b/QBImagePickerDemo/Info.plist
@@ -36,12 +36,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>hjgvcf</string>
 </dict>
 </plist>


### PR DESCRIPTION
This fixes the duration bug. And this also does the same format of Apple Photos app with rounding off.

----

**BEFORE:**

![simulator_screenshot_CF726730-2CCD-4958-885E-F1D2B0727994](https://github.com/fotonotes/QBImagePicker/assets/12502679/0f0e8931-9c2f-4070-b717-bf4ab7213c72)


----

**AFTER:**

![simulator_screenshot_6E0B1930-F805-417B-B694-BA4F1CFF31E3](https://github.com/fotonotes/QBImagePicker/assets/12502679/df69faa3-62f2-40e4-bce9-3eb0e16fb724)
